### PR TITLE
Rename the crate to `milagro_bls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "milagro_bls"
 version = "0.8.0"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>", "Kirk Baird <kirk@sigmaprime.io>", "Paul Hauner <paul@sigmaprime.io>"]
 description = "BLS12-381 signatures using the Apache Milagro curve library, targeting Ethereum 2.0"
-license = "Apache-2.0"
+license = "MIT/Apache-2.0"
 
 [[bench]]
 name = "bls381_benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "bls-aggregates"
-version = "0.7.0"
-authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>"]
-description = "Various signature schemes. BLS, MuSig"
-license = "MIT/Apache-2.0"
+name = "milagro_bls"
+version = "0.8.0"
+authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>", "Kirk Baird <kirk@sigmaprime.io>", "Paul Hauner <paul@sigmaprime.io>"]
+description = "BLS12-381 signatures using the Apache Milagro curve library, targeting Ethereum 2.0"
+license = "Apache-2.0"
 
 [[bench]]
 name = "bls381_benches"


### PR DESCRIPTION
Rename the crate from `bls-aggregates` to `milagro_bls` for the following reasons:

- Avoid conflicts with @lovesh's library.
- Communicates the the library is not only focused on aggregate signatures (i.e., it can do individual signatures too).