### PR TITLE
Change license to Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bls-aggregates"
 version = "0.7.0"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>"]
 description = "Various signature schemes. BLS, MuSig"
-license = "MIT/Apache-2.0"
+license = "Apache-2.0"
 
 [[bench]]
 name = "bls381_benches"


### PR DESCRIPTION
This repository was previously licensed as `MIT/Apache-2.0`. Given that the AMCL library is Apache 2.0, I don't think is it permitted to add the MIT license.

I will seek @lovesh's input on this, as I assume he did the initial `MIT/Apache-2.0` licensing.