### PR TITLE
Change from Keccak to SHA256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ amcl = { path = "./amcl", default-features = false }
 hex = { version = "0.3", optional = true }
 lazy_static = { version = "1.0", optional = true }
 rand = { version = "0.5", default-features = false }
-tiny-keccak = "1.4"
+ring = "0.14.6"
 yaml-rust = { version = "0.4", optional = true }
 
 # This cannot be specified as dev-dependencies. Otherwise a cargo bug will always resolve `rand` with `std` feature, which breaks `no_std` builds.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro_bls"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>", "Kirk Baird <kirk@sigmaprime.io>", "Paul Hauner <paul@sigmaprime.io>"]
 description = "BLS12-381 signatures using the Apache Milagro curve library, targeting Ethereum 2.0"
 license = "MIT/Apache-2.0"

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -2,10 +2,10 @@ extern crate amcl;
 #[cfg(feature = "std")]
 extern crate hex;
 extern crate rand;
-extern crate tiny_keccak;
+extern crate ring;
 
 use self::amcl::arch::Chunk;
-use self::tiny_keccak::Keccak;
+use self::ring::digest::{digest, SHA256};
 use super::errors::DecodeError;
 use BLSCurve::big::BIG;
 use BLSCurve::big::{MODBYTES as bls381_MODBYTES, NLEN};
@@ -155,11 +155,7 @@ pub fn multiply_cofactor(curve_point: &mut GroupG2) -> GroupG2 {
 
 // Provides a Keccak256 hash of given input.
 pub fn hash(input: &[u8]) -> Vec<u8> {
-    let mut keccak = Keccak::new_keccak256();
-    keccak.update(input);
-    let mut result = vec![0; 32];
-    keccak.finalize(result.as_mut_slice());
-    result
+    digest(&SHA256, input).as_ref().into()
 }
 
 // A pairing function for an GroupG2 point and GroupG1 point to FP12.

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -507,6 +507,8 @@ mod tests {
 
     #[test]
     #[allow(non_snake_case)]
+    // Test vectors use Keccak whilst this implementation uses SHA2.
+    #[should_panic]
     fn case02_message_hash_G2_compressed() {
         // Run tests from test_bls.yml
         let mut file = {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -162,6 +162,8 @@ mod tests {
     }
 
     #[test]
+    // Test vectors use Keccak whilst this implementation uses SHA2.
+    #[should_panic]
     fn case04_sign_messages() {
         // Run tests from test_bls.yml
         let mut file = {


### PR DESCRIPTION
Replaces Keccak hashing with SHA256.

Some of the YAML tests vectors were dependent upon Keccak, those tests have been marked as `should_fail` until the EF releases new, stable test vectors.