### PR TITLE
Zeroize the Secret Key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = { version = "1.0", optional = true }
 rand = { version = "0.5", default-features = false }
 ring = "0.14.6"
 yaml-rust = { version = "0.4", optional = true }
+zeroize = "0.9"
 
 # This cannot be specified as dev-dependencies. Otherwise a cargo bug will always resolve `rand` with `std` feature, which breaks `no_std` builds.
 criterion = { version = "0.2", optional = true }

--- a/amcl/Cargo.toml
+++ b/amcl/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["lovesh harchandani <lovesh.bond@gmail.com>"]
 
 [dependencies]
+zeroize = "0.9"
 
 [features]
 default = ["std"]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -2,12 +2,12 @@ extern crate amcl;
 extern crate rand;
 extern crate zeroize;
 
+use self::zeroize::Zeroize;
 use super::amcl_utils::{self, BigNum, GroupG1, CURVE_ORDER, MOD_BYTE_SIZE};
 use super::errors::DecodeError;
 use super::g1::G1Point;
 use super::rng::get_seeded_rng;
 use rand::Rng;
-use self::zeroize::Zeroize;
 #[cfg(feature = "std")]
 use std::fmt;
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -15,7 +15,7 @@ impl Signature {
     /// Instantiate a new Signature from a message and a SecretKey.
     pub fn new(msg: &[u8], d: u64, sk: &SecretKey) -> Self {
         let hash_point = hash_on_g2(msg, d);
-        let mut sig = hash_point.mul(&sk.x);
+        let mut sig = hash_point.mul_secret_key(&sk.x);
         sig.affine();
         Self {
             point: G2Point::from_raw(sig),
@@ -26,7 +26,7 @@ impl Signature {
     /// been hashed.
     pub fn new_hashed(msg_hash_real: &[u8], msg_hash_imaginary: &[u8], sk: &SecretKey) -> Self {
         let hash_point = map_to_g2(msg_hash_real, msg_hash_imaginary);
-        let mut sig = hash_point.mul(&sk.x);
+        let mut sig = hash_point.mul_secret_key(&sk.x);
         sig.affine();
         Self {
             point: G2Point::from_raw(sig),


### PR DESCRIPTION
## Issue

#3 

## Changes
Use zeroize to zero the bytes of the secret key when it is dropped.
Also zeroize the copies of the secret key when used in multiplication for generating signatures and public keys.