### PR TITLE
Fix renaming in benchmarks

### DIFF
--- a/benches/bls381_benches.rs
+++ b/benches/bls381_benches.rs
@@ -1,11 +1,11 @@
 extern crate amcl;
-extern crate bls_aggregates;
+extern crate milagro_bls;
 extern crate criterion;
 extern crate hex;
 extern crate rand;
 
 use self::amcl::bls381 as BLSCurve;
-use bls_aggregates::*;
+use milagro_bls::*;
 use criterion::{black_box, criterion_group, criterion_main, Benchmark, Criterion};
 use BLSCurve::big::BIG;
 use BLSCurve::ecp::ECP;

--- a/benches/bls381_benches.rs
+++ b/benches/bls381_benches.rs
@@ -1,12 +1,12 @@
 extern crate amcl;
-extern crate milagro_bls;
 extern crate criterion;
 extern crate hex;
+extern crate milagro_bls;
 extern crate rand;
 
 use self::amcl::bls381 as BLSCurve;
-use milagro_bls::*;
 use criterion::{black_box, criterion_group, criterion_main, Benchmark, Criterion};
+use milagro_bls::*;
 use BLSCurve::big::BIG;
 use BLSCurve::ecp::ECP;
 


### PR DESCRIPTION
This crate was renamed in c84bc399b2a03c1eae121a89b39bc044222560db, but the benchmark was not updated. 