### PR TITLE
Eth2.0 v0.10 Secret Key Range and Length

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro_bls"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>", "Kirk Baird <kirk@sigmaprime.io>", "Paul Hauner <paul@sigmaprime.io>"]
 description = "BLS12-381 signatures using the Apache Milagro curve library, targeting Ethereum 2.0"
 license = "Apache-2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,4 +3,5 @@ pub enum DecodeError {
     BadPoint,
     IncorrectSize,
     InvalidCompressionFlag,
+    InvalidSecretKeyRange,
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -15,7 +15,7 @@ impl Signature {
     /// Instantiate a new Signature from a message and a SecretKey.
     pub fn new(msg: &[u8], sk: &SecretKey) -> Self {
         let hash_point = hash_on_g2(msg);
-        let mut sig = hash_point.mul(&sk.x);
+        let mut sig = hash_point.mul(sk.as_raw());
         sig.affine();
         Self {
             point: G2Point::from_raw(sig),


### PR DESCRIPTION
# Issue

#18 

# Proposed Changes

Make the secret key range `1 <= sk <= r - 1`, where `r - 1` is the curve order

Allow secret key to be deserialised for any length <= 48 bytes

# Additional Comments

This will break `from_bytes` -> `as_bytes` round trip as `as_bytes` will always be 48 bytes and `from_bytes` may be less than 48 bytes