### PR TITLE
Add subgroup checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro_bls"
-version = "1.0.1"
+version = "1.0.0"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>", "Kirk Baird <kirk@sigmaprime.io>", "Paul Hauner <paul@sigmaprime.io>"]
 description = "BLS12-381 signatures using the Apache Milagro curve library, targeting Ethereum 2.0"
 license = "Apache-2.0"

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -146,7 +146,7 @@ impl AggregateSignature {
     pub fn fast_aggregate_verify_pre_aggregated(
         &self,
         msg: &[u8],
-        avk: &AggregatePublicKey,
+        aggregate_public_key: &AggregatePublicKey,
     ) -> bool {
         // Subgroup check for signature
         if !subgroup_check_g2(self.point.as_raw()) {
@@ -154,7 +154,7 @@ impl AggregateSignature {
         }
 
         let mut sig_point = self.point.clone();
-        let mut key_point = avk.point.clone();
+        let mut key_point = aggregate_public_key.point.clone();
         sig_point.affine();
         key_point.affine();
         let mut msg_hash_point = hash_to_curve_g2(msg);

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -179,7 +179,7 @@ impl AggregateSignature {
     pub fn verify_multiple_aggregate_signatures<'a, R, I>(rng: &mut R, signature_sets: I) -> bool
     where
         R: Rng + ?Sized,
-        I: Iterator<Item = (&'a AggregateSignature, &'a Vec<&'a PublicKey>, &'a [u8])>,
+        I: Iterator<Item = (&'a AggregateSignature, &'a [&'a PublicKey], &'a [u8])>,
     {
         // Sum of (AggregateSignature[i] * rand[i]) for all AggregateSignatures - S'
         let mut final_agg_sig = GroupG2::new();
@@ -664,7 +664,7 @@ mod tests {
 
         let mega_iter = aggregate_signatures_refs
             .into_iter()
-            .zip(public_keys_refs.iter())
+            .zip(public_keys_refs.iter().map(|x| x.as_slice()))
             .zip(msgs_refs.iter().map(|x| *x))
             .map(|((a, b), c)| (a, b, c));
 

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -401,8 +401,8 @@ mod tests {
             let mut signing_agg_pub = AggregatePublicKey::new();
             for keypair in &signing_kps {
                 let sig = Signature::new(&message, &keypair.sk);
-                assert!(sig.core_verify(&message, &keypair.pk));
-                assert!(!sig.core_verify(&message, &control_kp.pk));
+                assert!(sig.verify(&message, &keypair.pk));
+                assert!(!sig.verify(&message, &control_kp.pk));
                 agg_signature.add(&sig);
                 signing_agg_pub.add(&keypair.pk);
             }

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -3,10 +3,6 @@ use super::errors::DecodeError;
 #[cfg(feature = "std")]
 use std::fmt;
 
-pub trait G1Wrapper {
-    fn point(&self) -> &G1Point;
-}
-
 pub struct G1Point {
     point: GroupG1,
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -312,11 +312,11 @@ mod tests {
 
         let message = "cats".as_bytes();
         let signature = Signature::new(&message, &sk);
-        assert!(signature.core_verify(&message, &pk));
+        assert!(signature.verify(&message, &pk));
 
         let pk_bytes = pk.as_bytes();
         let pk = PublicKey::from_bytes(&pk_bytes).unwrap();
-        assert!(signature.core_verify(&message, &pk));
+        assert!(signature.verify(&message, &pk));
     }
 
     #[test]
@@ -326,6 +326,6 @@ mod tests {
 
         let message = "cats".as_bytes();
         let signature = Signature::new(&message, &sk);
-        assert!(signature.core_verify(&message, &pk));
+        assert!(signature.verify(&message, &pk));
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -5,7 +5,7 @@ extern crate zeroize;
 use self::zeroize::Zeroize;
 use super::amcl_utils::{self, Big, GroupG1, CURVE_ORDER, MODBYTES};
 use super::errors::DecodeError;
-use super::g1::{G1Point, G1Wrapper};
+use super::g1::G1Point;
 use super::rng::get_seeded_rng;
 use rand::Rng;
 #[cfg(feature = "std")]
@@ -88,12 +88,6 @@ impl Drop for SecretKey {
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct PublicKey {
     pub point: G1Point,
-}
-
-impl G1Wrapper for PublicKey {
-    fn point(&self) -> &G1Point {
-        &self.point
-    }
 }
 
 impl PublicKey {
@@ -318,11 +312,11 @@ mod tests {
 
         let message = "cats".as_bytes();
         let signature = Signature::new(&message, &sk);
-        assert!(signature.verify(&message, &pk));
+        assert!(signature.core_verify(&message, &pk));
 
         let pk_bytes = pk.as_bytes();
         let pk = PublicKey::from_bytes(&pk_bytes).unwrap();
-        assert!(signature.verify(&message, &pk));
+        assert!(signature.core_verify(&message, &pk));
     }
 
     #[test]
@@ -332,6 +326,6 @@ mod tests {
 
         let message = "cats".as_bytes();
         let signature = Signature::new(&message, &sk);
-        assert!(signature.verify(&message, &pk));
+        assert!(signature.core_verify(&message, &pk));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod signature;
 use self::amcl::bls381 as BLSCurve;
 
 pub use aggregates::{AggregatePublicKey, AggregateSignature};
-pub use amcl_utils::{compress_g2, decompress_g2, hash_on_g2};
+pub use amcl_utils::{compress_g2, decompress_g2, hash_to_curve_g2};
 pub use errors::DecodeError;
 pub use g1::G1Point;
 pub use g2::G2Point;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -27,8 +27,8 @@ impl Signature {
     /// CoreVerify
     ///
     /// Verifies the Signature against a PublicKey.
-    /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-2.7
-    pub fn core_verify(&self, msg: &[u8], pk: &PublicKey) -> bool {
+    /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3
+    pub fn verify(&self, msg: &[u8], pk: &PublicKey) -> bool {
         // Subgroup checks
         if !subgroup_check_g1(pk.point.as_raw()) || !subgroup_check_g2(self.point.as_raw()) {
             return false;
@@ -82,7 +82,7 @@ mod tests {
              */
             let bytes = m.as_bytes();
             let sig = Signature::new(&bytes, &sk);
-            assert!(sig.core_verify(&bytes, &vk));
+            assert!(sig.verify(&bytes, &vk));
 
             /*
              * Test serializing, then deserializing the signature
@@ -90,7 +90,7 @@ mod tests {
             let sig_bytes = sig.as_bytes();
             let new_sig = Signature::from_bytes(&sig_bytes).unwrap();
             assert_eq!(&sig.as_bytes(), &new_sig.as_bytes());
-            assert!(new_sig.core_verify(&bytes, &vk));
+            assert!(new_sig.verify(&bytes, &vk));
         }
     }
 
@@ -103,8 +103,8 @@ mod tests {
         let mut msg = "Some msg";
         let sig = Signature::new(&msg.as_bytes(), &sk);
         msg = "Other msg";
-        assert_eq!(sig.core_verify(&msg.as_bytes(), &vk), false);
+        assert_eq!(sig.verify(&msg.as_bytes(), &vk), false);
         msg = "";
-        assert_eq!(sig.core_verify(&msg.as_bytes(), &vk), false);
+        assert_eq!(sig.verify(&msg.as_bytes(), &vk), false);
     }
 }


### PR DESCRIPTION
# Issues addressed

#21 
#16 

# Proposed Changes

- Add subgroup checks for signatures
- Add subgroup checks for public keys where necessary
- Update function naming to reflect [BLS standards](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02) naming
- Add additional helper functions
