### PR TITLE
Remove `G1Point` and `G2Point` wrappers

### DIFF
--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -1050,7 +1050,7 @@ mod tests {
         let mut point = GroupG1::generator();
         point = point.mul(&multiplier);
         let public_key = PublicKey {
-            point: GroupG1::from_raw(point.clone()),
+            point: point.clone(),
         };
         let aggregate_public_key = AggregatePublicKey::from_public_key(&public_key);
 

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -7,8 +7,6 @@ use super::amcl_utils::{
     G1_BYTE_SIZE,
 };
 use super::errors::DecodeError;
-// use super::g1::G1Point;
-// use super::g2::G2Point;
 use super::keys::PublicKey;
 use super::signature::Signature;
 use rand::Rng;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -5,7 +5,6 @@ extern crate zeroize;
 use self::zeroize::Zeroize;
 use super::amcl_utils::{self, compress_g1, decompress_g1, Big, GroupG1, CURVE_ORDER, MODBYTES};
 use super::errors::DecodeError;
-// use super::g1::G1Point;
 use amcl::hash256::HASH256;
 use rand::Rng;
 #[cfg(feature = "std")]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -3,9 +3,9 @@ extern crate rand;
 extern crate zeroize;
 
 use self::zeroize::Zeroize;
-use super::amcl_utils::{self, Big, GroupG1, CURVE_ORDER, MODBYTES};
+use super::amcl_utils::{self, compress_g1, decompress_g1, Big, GroupG1, CURVE_ORDER, MODBYTES};
 use super::errors::DecodeError;
-use super::g1::G1Point;
+// use super::g1::G1Point;
 use amcl::hash256::HASH256;
 use rand::Rng;
 #[cfg(feature = "std")]
@@ -115,7 +115,7 @@ impl Drop for SecretKey {
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct PublicKey {
-    pub point: G1Point,
+    pub point: GroupG1,
 }
 
 impl PublicKey {
@@ -125,11 +125,11 @@ impl PublicKey {
             point: {
                 #[cfg(feature = "std")]
                 {
-                    G1Point::from_raw(amcl_utils::GENERATORG1.mul(sk.as_raw()))
+                    amcl_utils::GENERATORG1.mul(sk.as_raw())
                 }
                 #[cfg(not(feature = "std"))]
                 {
-                    G1Point::from_raw(amcl_utils::GroupG1::generator().mul(sk.as_raw()))
+                    amcl_utils::GroupG1::generator().mul(sk.as_raw())
                 }
             },
         }
@@ -137,20 +137,18 @@ impl PublicKey {
 
     /// Instantiate a PublicKey from some GroupG1 point.
     pub fn new_from_raw(pt: &GroupG1) -> Self {
-        PublicKey {
-            point: G1Point::from_raw(*pt),
-        }
+        PublicKey { point: pt.clone() }
     }
 
     /// Instantiate a PublicKey from compressed bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<PublicKey, DecodeError> {
-        let point = G1Point::from_bytes(bytes)?;
+        let point = decompress_g1(&bytes)?;
         Ok(Self { point })
     }
 
     /// Export the PublicKey to compressed bytes.
     pub fn as_bytes(&self) -> Vec<u8> {
-        self.point.as_bytes()
+        compress_g1(&self.point)
     }
 
     /// Export the public key to uncompress (x, y) bytes

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -5,7 +5,6 @@ use super::amcl_utils::{
     subgroup_check_g2, GroupG2,
 };
 use super::errors::DecodeError;
-// use super::g2::G2Point;
 use super::keys::{PublicKey, SecretKey};
 
 #[derive(Clone, PartialEq, Eq)]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,16 +1,17 @@
 extern crate amcl;
 
 use super::amcl_utils::{
-    self, ate2_evaluation, hash_to_curve_g2, subgroup_check_g1, subgroup_check_g2,
+    self, ate2_evaluation, compress_g2, decompress_g2, hash_to_curve_g2, subgroup_check_g1,
+    subgroup_check_g2, GroupG2,
 };
 use super::errors::DecodeError;
-use super::g2::G2Point;
+// use super::g2::G2Point;
 use super::keys::{PublicKey, SecretKey};
 
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Signature {
-    pub point: G2Point,
+    pub point: GroupG2,
 }
 
 impl Signature {
@@ -19,9 +20,7 @@ impl Signature {
         let hash_point = hash_to_curve_g2(msg);
         let mut sig = hash_point.mul(sk.as_raw());
         sig.affine();
-        Self {
-            point: G2Point::from_raw(sig),
-        }
+        Self { point: sig }
     }
 
     /// CoreVerify
@@ -30,7 +29,7 @@ impl Signature {
     /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3
     pub fn verify(&self, msg: &[u8], pk: &PublicKey) -> bool {
         // Subgroup checks
-        if !subgroup_check_g1(pk.point.as_raw()) || !subgroup_check_g2(self.point.as_raw()) {
+        if !subgroup_check_g1(&pk.point) || !subgroup_check_g2(&self.point) {
             return false;
         }
 
@@ -41,22 +40,22 @@ impl Signature {
         let mut generator_g1_negative = amcl_utils::GroupG1::generator();
         generator_g1_negative.neg();
         ate2_evaluation(
-            &self.point.as_raw(),
+            &self.point,
             &generator_g1_negative,
             &msg_hash_point,
-            &pk.point.as_raw(),
+            &pk.point,
         )
     }
 
     /// Instantiate a Signature from compressed bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Signature, DecodeError> {
-        let point = G2Point::from_bytes(bytes)?;
+        let point = decompress_g2(&bytes)?;
         Ok(Self { point })
     }
 
     /// Compress the Signature as bytes.
     pub fn as_bytes(&self) -> Vec<u8> {
-        self.point.as_bytes()
+        compress_g2(&self.point)
     }
 }
 


### PR DESCRIPTION
# Issues Addressed

#23 

# Proposed Changes

Removal of G1Point and G2Point wrappers.

# Additional Comments

This required update the underlying library to implement `Eq`.