### PR TITLE
Add subgroup checks for batch aggregate verification

### DIFF
--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -288,6 +288,7 @@ impl AggregateSignature {
     /// Input (AggregateSignature, PublicKey[m], Message(Vec<u8>))[n]
     /// Checks that each AggregateSignature is valid with a reduced number of pairings.
     /// https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407
+    /// Note: Assumes Proof of Possession of public keys.
     pub fn verify_multiple_aggregate_signatures<'a, R, I>(rng: &mut R, signature_sets: I) -> bool
     where
         R: Rng + ?Sized,
@@ -302,6 +303,11 @@ impl AggregateSignature {
         for (aggregate_signature, aggregate_public_key, message) in signature_sets {
             // Require at least one PublicKey added to the AggregatePublicKey
             if aggregate_public_key.is_empty() {
+                return false;
+            }
+
+            // Verify subgroup of each aggregate_signature
+            if !subgroup_check_g2(&aggregate_signature.point) {
                 return false;
             }
 


### PR DESCRIPTION
# What has been changed

Subgroup check has now been included for all `AggregateSignatures` in `verify_multiple_aggregate_signatures()`.

This is necessary as they are multiplied by a random value which may push the `AggregateSignature` into the correct subgroup and it may be crafted to verify successfully.