### PR TITLE
Bls v4

### DIFF
--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -3,8 +3,8 @@ extern crate rand;
 
 use super::amcl_utils::{
     self, ate2_evaluation, compress_g1, compress_g2, decompress_g1, decompress_g2, g1mul, g2mul,
-    hash_to_curve_g2, pair, subgroup_check_g1, subgroup_check_g2, AmclError, Big, GroupG1, GroupG2,
-    G1_BYTES, G2_BYTES,
+    hash_to_curve_g2, pair, subgroup_check_g2, AmclError, Big, GroupG1, GroupG2, G1_BYTES,
+    G2_BYTES,
 };
 use super::keys::PublicKey;
 use super::signature::Signature;
@@ -179,8 +179,8 @@ impl AggregateSignature {
         let mut pairing = pair::initmp();
 
         for (i, pk) in public_keys.iter().enumerate() {
-            // Subgroup check for public key
-            if !subgroup_check_g1(&pk.point) {
+            // Validate public key
+            if !pk.key_validate() {
                 return false;
             }
 
@@ -213,7 +213,8 @@ impl AggregateSignature {
 
     /// FastAggregateVerify
     ///
-    /// Verifies an AggregateSignature against a list of PublicKeys
+    /// Verifies an AggregateSignature against a list of PublicKeys.
+    /// PublicKeys must all be verified via Proof of Possession before running this function.
     /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3.4
     pub fn fast_aggregate_verify(&self, msg: &[u8], public_keys: &[&PublicKey]) -> bool {
         // Require at least one PublicKey
@@ -249,6 +250,7 @@ impl AggregateSignature {
     /// FastAggregateVerify - pre-aggregated PublicKeys
     ///
     /// Verifies an AggregateSignature against an AggregatePublicKey.
+    /// PublicKeys should all be verified before being aggregated.
     /// Differs to IEFT FastAggregateVerify in that public keys are already aggregated.
     /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3.4
     pub fn fast_aggregate_verify_pre_aggregated(

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -17,7 +17,7 @@ use rand::Rng;
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct AggregatePublicKey {
     pub point: GroupG1,
-    is_empty: bool,
+    pub is_empty: bool,
 }
 
 impl AggregatePublicKey {

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -34,6 +34,8 @@ impl AggregatePublicKey {
     /// Instantiate a new aggregate public key from a vector of PublicKeys.
     ///
     /// This is a helper method combining the `new()` and `add()` functions.
+    ///
+    /// Pre-requsites: All public keys must be PoP verified before calling this function.
     pub fn aggregate(keys: &[&PublicKey]) -> Self {
         let mut agg_key = Self {
             point: GroupG1::new(),
@@ -54,12 +56,16 @@ impl AggregatePublicKey {
     }
 
     /// Add a PublicKey to the AggregatePublicKey.
+    ///
+    /// Pre-requsites: Public keys must be PoP verified before calling this function.
     pub fn add(&mut self, public_key: &PublicKey) {
         self.point.add(&public_key.point);
         self.is_empty = false;
     }
 
     /// Add a AggregatePublicKey to the AggregatePublicKey.
+    ///
+    /// Pre-requsites: All public keys must be PoP verified before calling this function.
     pub fn add_aggregate(&mut self, aggregate_public_key: &AggregatePublicKey) {
         self.point.add(&aggregate_public_key.point);
         self.is_empty = self.is_empty && aggregate_public_key.is_empty;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,8 +1,8 @@
 extern crate amcl;
 
 use super::amcl_utils::{
-    self, ate2_evaluation, compress_g2, decompress_g2, g2mul, hash_to_curve_g2, subgroup_check_g1,
-    subgroup_check_g2, AmclError, GroupG2, G2_BYTES,
+    self, ate2_evaluation, compress_g2, decompress_g2, g2mul, hash_to_curve_g2, subgroup_check_g2,
+    AmclError, GroupG2, G2_BYTES,
 };
 use super::keys::{PublicKey, SecretKey};
 
@@ -25,8 +25,12 @@ impl Signature {
     /// Verifies the Signature against a PublicKey.
     /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3
     pub fn verify(&self, msg: &[u8], pk: &PublicKey) -> bool {
-        // Subgroup checks
-        if !subgroup_check_g1(&pk.point) || !subgroup_check_g2(&self.point) {
+        // Signature Subgroup checks
+        if !subgroup_check_g2(&self.point) {
+            return false;
+        }
+        // KeyValidate
+        if !pk.key_validate() {
             return false;
         }
 


### PR DESCRIPTION
# What has been done

This has been updated to [BLS Signature Standards Version 4](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04).

This also updates hash to curve to version 9 which has no relevant changes for our implementation.