### PR TITLE
Secret key 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro_bls"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>", "Kirk Baird <kirk@sigmaprime.io>", "Paul Hauner <paul@sigmaprime.io>"]
 description = "BLS12-381 signatures using the Apache Milagro curve library, targeting Ethereum 2.0"
 license = "Apache-2.0"

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -233,6 +233,11 @@ impl AggregateSignature {
             return false;
         }
 
+        // Additional Check to ensure no infinity public keys
+        if public_keys.iter().any(|pk| pk.point.is_infinity()) {
+            return false;
+        }
+
         // Aggregate PublicKeys
         let aggregate_public_key = AggregatePublicKey::aggregate(public_keys);
 
@@ -256,7 +261,7 @@ impl AggregateSignature {
     /// FastAggregateVerify - pre-aggregated PublicKeys
     ///
     /// Verifies an AggregateSignature against an AggregatePublicKey.
-    /// PublicKeys should all be verified before being aggregated.
+    /// PublicKeys must all be verified before being aggregated.
     /// Differs to IEFT FastAggregateVerify in that public keys are already aggregated.
     /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3.4
     pub fn fast_aggregate_verify_pre_aggregated(

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -214,7 +214,7 @@ impl AggregateSignature {
         // Complete pairing and verify output is 1.
         let mut v = pair::miller(&pairing);
         v = pair::fexp(&v);
-        v.isunity()
+        v.is_unity()
     }
 
     /// FastAggregateVerify
@@ -356,7 +356,7 @@ impl AggregateSignature {
         // Complete pairing and verify output is 1.
         let mut v = pair::miller(&pairing);
         v = pair::fexp(&v);
-        v.isunity()
+        v.is_unity()
     }
 
     /// Instatiate an AggregateSignature from some bytes.

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -103,7 +103,7 @@ mod tests {
         let mut point = GroupG1::new();
         let compressed = compress_g1(&mut point);
         let round_trip_point = decompress_g1(&compressed).unwrap();
-        assert_eq!(point.tostring(), round_trip_point.tostring());
+        assert_eq!(point.to_string(), round_trip_point.to_string());
     }
 
     #[test]
@@ -111,7 +111,7 @@ mod tests {
         let mut point = GroupG2::new();
         let compressed = compress_g2(&mut point);
         let round_trip_point = decompress_g2(&compressed).unwrap();
-        assert_eq!(point.tostring(), round_trip_point.tostring());
+        assert_eq!(point.to_string(), round_trip_point.to_string());
     }
 
     #[test]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -43,7 +43,7 @@ impl SecretKey {
         let mut sk = Big::new();
         let mut salt = KEY_SALT.to_vec();
 
-        while sk.iszilch() {
+        while sk.is_zilch() {
             // salt = H(salt)
             let mut hash256 = HASH256::new();
             hash256.init();
@@ -63,7 +63,7 @@ impl SecretKey {
 
             // SK = OS2IP(OKM) mod r
             let r = Big::new_ints(&CURVE_ORDER);
-            sk = Big::frombytes(&okm);
+            sk = Big::from_bytes(&okm);
             sk.rmod(&r);
         }
         Self { x: sk }
@@ -89,7 +89,7 @@ impl SecretKey {
 #[cfg(feature = "std")]
 impl fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.x.tostring())
+        write!(f, "{}", self.x.to_string())
     }
 }
 
@@ -297,7 +297,10 @@ mod tests {
         );
 
         let bytes = vec![0; 32];
-        assert!(SecretKey::from_bytes(&bytes).is_ok());
+        assert_eq!(
+            SecretKey::from_bytes(&bytes),
+            Err(AmclError::InvalidSecretKeyRange)
+        );
 
         let bytes = vec![255; 32];
         assert_eq!(


### PR DESCRIPTION
# Updates

- SK = 0 is now rejected from `SecretKey::from_bytes()`
- `fast_aggregate_verify()` will return false if any public keys are infinity. Note this is a failure of the pre-conditions anyway as `fast_aggregate_verify()` can only be called on PoP verified public keys which infinity cannot be PoP verified.
- Some underlying apache functions names have been modified to match rust formatting guides. (e.g. `isunity()` -> `is_unity()`)