### PR TITLE
Update rand dep to 0.8.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ harness = false
 amcl = { path = "./incubator-milagro-crypto-rust", default-features = false, features = ["bls381"]}
 hex = { version = "0.4.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
-rand = { version = "0.7.2", default-features = false }
+rand = { version = "0.8.5", default-features = false }
 zeroize = "1.0.0"
 
 # This cannot be specified as dev-dependencies. Otherwise a cargo bug will always resolve `rand` with `std` feature, which breaks `no_std` builds.
@@ -24,6 +24,7 @@ default = ["std"]
 bench = ["criterion"]
 std = [
   "rand/std",
+  "rand/std_rng",
   "lazy_static",
   "hex",
 ]


### PR DESCRIPTION
Most of the Rust crate ecosystem has already moved to rand 0.8. Lighthouse is close to getting off rand 0.7 altogether with https://github.com/sigp/lighthouse/pull/3136, and this change would push us one step closer.