### PR TITLE
Ikm length

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro_bls"
-version = "1.4.2"
+version = "1.5.0"
 authors = ["Lovesh Harchandani <lovesh.bond@gmail.com>", "Kirk Baird <kirk@sigmaprime.io>", "Paul Hauner <paul@sigmaprime.io>"]
 description = "BLS12-381 signatures using the Apache Milagro curve library, targeting Ethereum 2.0"
 license = "Apache-2.0"

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -31,9 +31,7 @@ impl AggregatePublicKey {
             return Err(AmclError::AggregateEmptyPoints);
         }
 
-        let mut agg_key = Self {
-            point: GroupG1::new(),
-        };
+        let mut agg_key = Self { point: GroupG1::new() };
         for key in keys {
             agg_key.point.add(&key.point)
         }
@@ -54,16 +52,14 @@ impl AggregatePublicKey {
         for key in keys {
             point.add(&key.point)
         }
-        Ok(Self { point: point })
+        Ok(Self { point })
     }
 
     /// Instantiate a new aggregate public key from a single PublicKey.
     ///
     /// Pre-requsites: Public key must be PoP verified before calling this function.
     pub fn from_public_key(key: &PublicKey) -> Self {
-        AggregatePublicKey {
-            point: key.point.clone(),
-        }
+        AggregatePublicKey { point: key.point.clone() }
     }
 
     /// Add a PublicKey to the AggregatePublicKey.
@@ -95,9 +91,7 @@ impl AggregateSignature {
     ///
     /// The underlying point will be set to infinity.
     pub fn new() -> Self {
-        Self {
-            point: GroupG2::new(),
-        }
+        Self { point: GroupG2::new() }
     }
 
     /// Instantiate a new AggregateSignature from a vector of Signatures.
@@ -113,9 +107,7 @@ impl AggregateSignature {
 
     /// Instantiate a new AggregateSignature from a single Signature.
     pub fn from_signature(signature: &Signature) -> Self {
-        AggregateSignature {
-            point: signature.point.clone(),
-        }
+        AggregateSignature { point: signature.point.clone() }
     }
 
     /// Add a Signature to the AggregateSignature.
@@ -137,7 +129,7 @@ impl AggregateSignature {
     /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3
     pub fn aggregate_verify(&self, msgs: &[&[u8]], public_keys: &[&PublicKey]) -> bool {
         // Require same number of messages as PublicKeys and >=1 PublicKeys.
-        if msgs.len() != public_keys.len() || public_keys.len() == 0 {
+        if msgs.len() != public_keys.len() || public_keys.is_empty() {
             return false;
         }
 
@@ -184,7 +176,7 @@ impl AggregateSignature {
     /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3.4
     pub fn fast_aggregate_verify(&self, msg: &[u8], public_keys: &[&PublicKey]) -> bool {
         // Require at least one PublicKey
-        if public_keys.len() == 0 {
+        if public_keys.is_empty() {
             return false;
         }
 
@@ -210,7 +202,7 @@ impl AggregateSignature {
 
         // Points must be affine for pairing
         let mut sig_point = self.point.clone();
-        let mut key_point = aggregate_public_key.point.clone();
+        let mut key_point = aggregate_public_key.point;
         sig_point.affine();
         key_point.affine();
         msg_hash.affine();
@@ -288,7 +280,7 @@ impl AggregateSignature {
             let mut rand = 0;
             while rand == 0 {
                 // Require: rand > 0
-                let mut rand_bytes = [0 as u8; 8]; // bytes
+                let mut rand_bytes = [0u8; 8]; // bytes
                 rng.fill(&mut rand_bytes);
                 rand = i64::from_be_bytes(rand_bytes).abs();
             }
@@ -325,7 +317,7 @@ impl AggregateSignature {
 
     /// Instatiate an AggregateSignature from some bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<AggregateSignature, AmclError> {
-        let point = decompress_g2(&bytes)?;
+        let point = decompress_g2(bytes)?;
         Ok(Self { point })
     }
 
@@ -405,7 +397,9 @@ mod tests {
         let sk = SecretKey::from_bytes(&sk_bytes).unwrap(); // 1
         let pk = PublicKey::from_secret_key(&sk);
 
-        let sk_bytes = hex::decode("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000").unwrap();
+        let sk_bytes =
+            hex::decode("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000")
+                .unwrap();
         let neg_sk = SecretKey::from_bytes(&sk_bytes).unwrap(); // -1
         let neg_pk = PublicKey::from_secret_key(&neg_sk);
 
@@ -439,11 +433,7 @@ mod tests {
             subset
         };
 
-        let messages = vec![
-            "Small msg".as_bytes(),
-            "cats lol".as_bytes(),
-            &[42_u8; 133700],
-        ];
+        let messages = vec!["Small msg".as_bytes(), "cats lol".as_bytes(), &[42_u8; 133700]];
 
         for message in messages {
             let mut agg_signature = AggregateSignature::new();
@@ -943,9 +933,7 @@ mod tests {
         let multiplier = Big::new_int(5);
         let mut point = GroupG1::generator();
         point = point.mul(&multiplier);
-        let public_key = PublicKey {
-            point: point.clone(),
-        };
+        let public_key = PublicKey { point: point.clone() };
         let aggregate_public_key = AggregatePublicKey::from_public_key(&public_key);
 
         assert_eq!(public_key.point, aggregate_public_key.point);

--- a/src/amcl_utils.rs
+++ b/src/amcl_utils.rs
@@ -36,7 +36,7 @@ pub fn hash_to_curve_g2(msg: &[u8]) -> GroupG2 {
 
 // Evaluation of e(A, B) * e(C, D) == 1
 pub fn ate2_evaluation(a: &GroupG2, b: &GroupG1, c: &GroupG2, d: &GroupG1) -> bool {
-    let mut pairing = ate2(&a, &b, &c, &d);
+    let mut pairing = ate2(a, b, c, d);
     pairing = fexp(&pairing);
     FP12::new_int(1).equals(&pairing)
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -75,9 +75,7 @@ impl SecretKey {
 
     /// Instantiate a SecretKey from existing bytes.
     pub fn from_bytes(input: &[u8]) -> Result<SecretKey, AmclError> {
-        Ok(Self {
-            x: secret_key_from_bytes(input)?,
-        })
+        Ok(Self { x: secret_key_from_bytes(input)? })
     }
 
     /// Export the SecretKey as 32 bytes.
@@ -147,7 +145,7 @@ impl PublicKey {
 
     /// Instantiate a PublicKey from compressed bytes.
     pub fn from_bytes_unchecked(bytes: &[u8]) -> Result<PublicKey, AmclError> {
-        let point = decompress_g1(&bytes)?;
+        let point = decompress_g1(bytes)?;
         let public_key = Self { point };
 
         Ok(public_key)
@@ -170,9 +168,7 @@ impl PublicKey {
         if bytes.len() != G1_BYTES * 2 {
             return Err(AmclError::InvalidG1Size);
         }
-        Ok(Self {
-            point: deserialize_g1(bytes)?,
-        })
+        Ok(Self { point: deserialize_g1(bytes)? })
     }
 
     /// KeyValidate
@@ -261,28 +257,16 @@ mod tests {
     #[test]
     fn test_public_key_uncompressed_serialization_incorrect_size() {
         let bytes = vec![1; 1];
-        assert_eq!(
-            PublicKey::from_uncompressed_bytes(&bytes),
-            Err(AmclError::InvalidG1Size)
-        );
+        assert_eq!(PublicKey::from_uncompressed_bytes(&bytes), Err(AmclError::InvalidG1Size));
 
         let bytes = vec![1; 95];
-        assert_eq!(
-            PublicKey::from_uncompressed_bytes(&bytes),
-            Err(AmclError::InvalidG1Size)
-        );
+        assert_eq!(PublicKey::from_uncompressed_bytes(&bytes), Err(AmclError::InvalidG1Size));
 
         let bytes = vec![1; 97];
-        assert_eq!(
-            PublicKey::from_uncompressed_bytes(&bytes),
-            Err(AmclError::InvalidG1Size)
-        );
+        assert_eq!(PublicKey::from_uncompressed_bytes(&bytes), Err(AmclError::InvalidG1Size));
 
         let bytes = vec![];
-        assert_eq!(
-            PublicKey::from_uncompressed_bytes(&bytes),
-            Err(AmclError::InvalidG1Size)
-        );
+        assert_eq!(PublicKey::from_uncompressed_bytes(&bytes), Err(AmclError::InvalidG1Size));
     }
 
     #[test]
@@ -291,37 +275,22 @@ mod tests {
         let mut bytes = vec![0; 96];
         bytes[47] = 1;
         bytes[95] = 1;
-        assert_eq!(
-            PublicKey::from_uncompressed_bytes(&bytes),
-            Err(AmclError::InvalidPoint)
-        );
+        assert_eq!(PublicKey::from_uncompressed_bytes(&bytes), Err(AmclError::InvalidPoint));
     }
 
     #[test]
     fn test_secret_key_from_bytes() {
         let bytes = vec![];
-        assert_eq!(
-            SecretKey::from_bytes(&bytes),
-            Err(AmclError::InvalidSecretKeySize)
-        );
+        assert_eq!(SecretKey::from_bytes(&bytes), Err(AmclError::InvalidSecretKeySize));
 
         let bytes = vec![1; 33];
-        assert_eq!(
-            SecretKey::from_bytes(&bytes),
-            Err(AmclError::InvalidSecretKeySize)
-        );
+        assert_eq!(SecretKey::from_bytes(&bytes), Err(AmclError::InvalidSecretKeySize));
 
         let bytes = vec![0; 32];
-        assert_eq!(
-            SecretKey::from_bytes(&bytes),
-            Err(AmclError::InvalidSecretKeyRange)
-        );
+        assert_eq!(SecretKey::from_bytes(&bytes), Err(AmclError::InvalidSecretKeyRange));
 
         let bytes = vec![255; 32];
-        assert_eq!(
-            SecretKey::from_bytes(&bytes),
-            Err(AmclError::InvalidSecretKeyRange)
-        );
+        assert_eq!(SecretKey::from_bytes(&bytes), Err(AmclError::InvalidSecretKeyRange));
     }
 
     #[test]
@@ -364,10 +333,7 @@ mod tests {
         let mut pk_bytes = vec![0; 48];
         pk_bytes[0] = 128;
 
-        assert_eq!(
-            PublicKey::from_bytes(&pk_bytes),
-            Err(AmclError::InvalidPoint)
-        );
+        assert_eq!(PublicKey::from_bytes(&pk_bytes), Err(AmclError::InvalidPoint));
         assert!(PublicKey::from_bytes_unchecked(&pk_bytes).is_ok());
     }
 
@@ -377,10 +343,7 @@ mod tests {
         let mut pk_bytes = vec![0; 48];
         pk_bytes[0] = 196;
 
-        assert_eq!(
-            PublicKey::from_bytes(&pk_bytes),
-            Err(AmclError::InvalidPoint)
-        );
+        assert_eq!(PublicKey::from_bytes(&pk_bytes), Err(AmclError::InvalidPoint));
     }
 
     #[test]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -36,17 +36,12 @@ impl Signature {
         // Faster ate2 evaualtion checks e(S, -G1) * e(H, PK) == 1
         let mut generator_g1_negative = amcl_utils::GroupG1::generator();
         generator_g1_negative.neg();
-        ate2_evaluation(
-            &self.point,
-            &generator_g1_negative,
-            &msg_hash_point,
-            &pk.point,
-        )
+        ate2_evaluation(&self.point, &generator_g1_negative, &msg_hash_point, &pk.point)
     }
 
     /// Instantiate a Signature from compressed bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Signature, AmclError> {
-        let point = decompress_g2(&bytes)?;
+        let point = decompress_g2(bytes)?;
         Ok(Self { point })
     }
 


### PR DESCRIPTION
## What issue does this relate too?

Fixes #45 

## What has been changed?

- Error for `SecretKey::key_generate()` if there is less than 32 bytes of IKM
- Fixed clippy lints
- Minor version bump