### PR TITLE
Use immutable ref for `as_uncompressed_bytes`

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -157,7 +157,7 @@ impl PublicKey {
     }
 
     /// Export the public key to uncompress (x, y) bytes
-    pub fn as_uncompressed_bytes(&mut self) -> [u8; G1_BYTES * 2] {
+    pub fn as_uncompressed_bytes(&self) -> [u8; G1_BYTES * 2] {
         serialize_uncompressed_g1(&self.point)
     }
 


### PR DESCRIPTION
While updating Lighthouse to utilise uncompressed public keys on disk (https://github.com/sigp/lighthouse/issues/3505) I ran into an issue where `PublicKey::as_uncompressed_bytes` requires `&mut self` but actually only needs `&self`.